### PR TITLE
Update copyright in license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,7 @@
-Copyright (c) 2014-2015 John Otander
+Copyright (c) 2014-2018 John Otander
+Copyright (c) 2014 Daniel Eden for animate.css
+Copyright (c) 2014 Brent Jackson for Basscss
+Copyright (c) 2013 Twitter, Inc for CSS copied from Bootstrap
 
 MIT License
 


### PR DESCRIPTION
Update John Otander copyright to 2018.

Add copyrights for Danel Eden, Brent Jackson and Twitter, since their code is copied in this project.