### PR TITLE
Fix nav links with baseurl

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header px2 px-responsive">
   <div class="mt2 wrap">
     <div class="measure">
-      <a href="{{ site.url }}" class="site-title">{{ site.title }}</a>
+      <a href="{{ "/" | relative_url }}" class="site-title">{{ site.title }}</a>
       <nav class="site-nav">
         {% include navigation.html %}
       </nav>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
     {% assign page = site.pages | where: "path", path | first %}
     
     {% if page.title %}
-        <a href="{{ page.url }}">{{ page.title }}</a>
+        <a href="{{ page.url | relative_url }}">{{ page.title }}</a>
     {% endif %}
 
     


### PR DESCRIPTION
There's a new feature, called `relative_url`, that is useful for "doing the right thing" with `baseurl`:

https://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/

Fixes #369.