### PR TITLE
Fix baseurl for Favicon and Apple icons

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -77,20 +77,21 @@
     {% endif %}
 
     <!-- Icons -->
-    <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" href="/favicon-192x192.png" sizes="192x192">
-    <link rel="icon" type="image/png" href="/favicon-160x160.png" sizes="160x160">
-    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+    <link rel="apple-touch-icon" sizes="57x57" href="{{ "/apple-touch-icon-57x57.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="114x114" href="{{ "/apple-touch-icon-114x114.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="72x72" href="{{ "/apple-touch-icon-72x72.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="144x144" href="{{ "/apple-touch-icon-144x144.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="60x60" href="{{ "/apple-touch-icon-60x60.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="120x120" href="{{ "/apple-touch-icon-120x120.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="76x76" href="{{ "/apple-touch-icon-76x76.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="152x152" href="{{ "/apple-touch-icon-152x152.png" | relative_url }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ "/apple-touch-icon-180x180.png" | relative_url }}">
+    <link rel="icon" type="image/png" href="{{ "/favicon-192x192.png" | relative_url }}" sizes="192x192">
+    <link rel="icon" type="image/png" href="{{ "/favicon-160x160.png" | relative_url }}" sizes="160x160">
+    <link rel="icon" type="image/png" href="{{ "/favicon-96x96.png" | relative_url }}" sizes="96x96">
+    <link rel="icon" type="image/png" href="{{ "/favicon-16x16.png" | relative_url }}" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ "/favicon-32x32.png" | relative_url }}" sizes="32x32">
+    <link rel="shortcut icon" href="{{ "/favicon.ico" | relative_url }}"
 
     {% if site.google_analytics %}
     <script type="text/javascript">


### PR DESCRIPTION
Currently, the favicons and Apple touch icons are assumed to be in the server root directory.  This won't work with `baseurl`.  We need to add an element for `favicon.ico`, so that it's location could be overridden.

This is similar to the fix for #370.