### PR TITLE
Build in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+# appveyor.yml
+
+environment:
+  RUBY_VERSION: 25
+
+platform:
+  - x64
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+before_build:
+  - ruby -v
+  - gem -v
+  - bundle -v
+  - bundle exec jekyll -v
+
+build_script:
+  - bundle exec jekyll build


### PR DESCRIPTION
Automated builds specifically on Windows may benefit those users.  Although, I predict it isn't necessary:  The entire stack (Ruby, bundler, Jekyll) should be so portable these days that it is of no concern.  

However, maybe there's a chance this is generally useful as a starting point to some users.  Appveyor would be the recommendation.  And a Windows build may be helpful should we run in to issues specific to Windows users with gem-based themes for #333 and #360.

Before merging this, @johno would need to [sign-in](https://ci.appveyor.com/login) at Appveyor and enable this repo.