### PR TITLE
Fix missing bracket on link tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -91,7 +91,7 @@
     <link rel="icon" type="image/png" href="{{ "/favicon-96x96.png" | relative_url }}" sizes="96x96">
     <link rel="icon" type="image/png" href="{{ "/favicon-16x16.png" | relative_url }}" sizes="16x16">
     <link rel="icon" type="image/png" href="{{ "/favicon-32x32.png" | relative_url }}" sizes="32x32">
-    <link rel="shortcut icon" href="{{ "/favicon.ico" | relative_url }}"
+    <link rel="shortcut icon" href="{{ "/favicon.ico" | relative_url }}">
 
     {% if site.google_analytics %}
     <script type="text/javascript">


### PR DESCRIPTION
This defect was introduced in #371.

Fixes #376.