### PR TITLE
Fix txtpen

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,8 +34,8 @@ layout: default
   {% include post_footer.html %}
 {% endif %}
 
-{% if txtpen.txtpen_sitename %}
-  <script src="https://txtpen.com/embed.js?site={{txtpen.txtpen_sitename}}" />
+{% if site.txtpen_sitename %}
+  <script src="https://txtpen.com/embed.js?site={{site.txtpen_sitename}}" />
 {% endif %}
 
 {% if site.disqus_shortname %}


### PR DESCRIPTION
I modified the `_config.yml` as such:

    txtpen_sitename: "pixyll.com"

And the Javascript wouldn't load.  There was a defect in the post layout file from #325:

https://github.com/johno/pixyll/blob/74ce90f25b86428bffe0a2d9d32c1e8f8a5dbf57/_layouts/post.html#L37-L39

But after fixing it, I'm seeing that txtpen.com is unreachable.

    GET https://txtpen.com/embed.js?site=pixyll.com
    net::ERR_ABORTED 522

Did this service get discontinued?

If this service is shut down, then we should just rip this out and not fix it.