### PR TITLE
Drop txtpen revert #325

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,6 @@ More setup instructions and advanced options can be found at [http://formspree.i
 
 To configure Disqus, set up a [Disqus site](https://disqus.com/admin/create/) with the same name as your site. Then, in `_config.yml`, edit the `disqus_shortname` value to enable Disqus.
 
-### txtpen
-
-To configure txtpen, set up a [txtpen site](https://txtpen.com/go) with the same name as your site. Then, in `_config.yml`, edit the `txtpen_sitename` value to enable txtpen
-
 ### Customizing the CSS
 
 All variables can be found in the `_sass/_variables.scss` file, toggle these as you'd like to change the look and feel of Pixyll.

--- a/_config.yml
+++ b/_config.yml
@@ -40,10 +40,6 @@ fb_page_id:
 # (leave blank to disable Disqus)
 disqus_shortname:
 
-# txtpen post comments
-# (leave blank to disable txtpen)
-txtpen_sitename:
-
 # Facebook Comments plugin
 # (leave blank to disable Facebook Comments, otherwise set it to true)
 facebook_comments:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -34,10 +34,6 @@ layout: default
   {% include post_footer.html %}
 {% endif %}
 
-{% if txtpen.txtpen_sitename %}
-  <script src="https://txtpen.com/embed.js?site={{txtpen.txtpen_sitename}}" />
-{% endif %}
-
 {% if site.disqus_shortname %}
   <div id="disqus_thread"></div>
   <script type="text/javascript">


### PR DESCRIPTION
Looks like the service was shutdown.  There's evidence that it wasn't even usable in Pixyll, so no big loss.

Reverts 9f383dc.