### PR TITLE
Switch to Ruby 2.5 and 2.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
- - 2.1
- - 2.2
  - 2.3
  - 2.4
+ - 2.5
+ - 2.6
 script:
  - bundle exec jekyll build
  - grep johnotander/pixyll _site/index.html


### PR DESCRIPTION
Ruby 2.1 and 2.2 are no longer being maintained, and they also fail to build in Travis.  

Time for the new stuff!