### PR TITLE
Add rake task to publish a draft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
  - 2.6
 script:
  - bundle exec jekyll build
+ - rake 'draft[Hello\, world]'
+ - rake undraft[hello-world.md]
  - grep johnotander/pixyll _site/index.html
  - grep post-title         _site/index.html
  - grep pagination-item    _site/index.html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,11 @@ install:
 before_build:
   - ruby -v
   - gem -v
+  - rake --version
   - bundle -v
   - bundle exec jekyll -v
 
 build_script:
   - bundle exec jekyll build
+  - rake 'draft[Hello\, world]'
+  - rake undraft[hello-world.md]


### PR DESCRIPTION
Fixes #310:

    rake undraft[hello-world.md]

It will do the following:

- Moves the file from the `_drafts` folder to the `_posts` folder
- Prepends the date to the beginning of the filename
- Updates the `date:` field to the current date.
