### PR TITLE
Add default date format to pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,13 @@ layout: default
     <div class="posts">
       {% for post in paginator.posts %}
         <div class="post py3">
-          <p class="post-meta">{{ post.date | date: site.date_format }}</p>
+          <p class="post-meta">
+	    {% if site.date_format %}
+	      {{ post.date | date: site.date_format }}
+	    {% else %}
+	      {{ post.date | date: "%b %-d, %Y" }}
+	    {% endif %}
+	  </p>
           <a href="{{ post.url | relative_url }}" class="post-link"><h3 class="h1 post-title">{{ post.title }}</h3></a>
           <span class="post-summary">
             {% if post.summary %}


### PR DESCRIPTION
This is similar to #389.  If people don't have this configured in their `_config.yml`, then things will break.  This was also pulled from #334, since it shouldn't be a breaking change.