### PR TITLE
Add initial Service Worker

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,3 +12,8 @@
     anchors.options.visible = 'always';
     anchors.add('article h2, article h3, article h4, article h5, article h6');
 </script>{% endif %}
+<script type="text/javascript">
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("{{ '/sw.js' | relative_url }}")
+    }
+</script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,54 @@
+---
+layout: null
+---
+var CACHE_NAME = "pixyll2-{{site.time | date: '%Y%m%d%H%M%S'}}";
+
+self.addEventListener("install", function(e) {
+  e.waitUntil(
+    caches.open(CACHE_NAME).then(function(cache) {
+      return cache.addAll([
+        "{{ '/css/pixyll.css' | relative_url }}?{{ site.time | date: '%Y%m%d%H%M' }}",
+        "{{ '/' | relative_url }}"
+      ]);
+    })
+  );
+});
+
+self.addEventListener("activate", function(e) {
+  e.waitUntil(
+    caches.keys().then(function(names) {
+      return Promise.all(
+        names.map(function(name) {
+          if (name != CACHE_NAME) {
+            return caches.delete(name);
+          }
+        })
+      );
+    })
+  );
+  return clients.claim();
+});
+
+addEventListener("fetch", function(e) {
+  e.respondWith(
+    caches.match(e.request).then(function(response) {
+        return response || fetch(e.request).then(function(response) {
+        var clonedResponse = response.clone();
+        var hosts = [
+          "https://fonts.googleapis.com",
+          "https://fonts.gstatic.com",
+          "https://maxcdn.bootstrapcdn.com",
+          "https://cdnjs.cloudflare.com"
+        ];
+        hosts.map(function(host) {
+          if (e.request.url.indexOf(host) === 0) {
+            caches.open(CACHE_NAME).then(function(cache) {
+              cache.put(e.request, clonedResponse);
+            });
+          }
+        });
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
This adds a very barebones service worker.  Offline mode will be of some assistance to people who are on mobile.

The only assets we can guarantee exist on a PIxyll site are:

1. the stylesheet and 
2. the home page.
  
Next steps could be adding the assets related to Google fonts, Font Awessome and MathJax.   I had issues adding them, but I can loop back on it, or maybe someone can take a look.

Additional support for a Progressive web app could be added to Pixyll.  A Jekyll site probably wouldn't be able to benefit from being a full Progressive web app, nor would it be worth the effort.

PS. The service worker will be disabled on pixyll.com because it's not HTTPS, so browsers will just ignore the service worker.