### PR TITLE
Exclude more files from Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -127,4 +127,5 @@ exclude:
   - Gemfile.lock
   - Rakefile
   - README.md
+  - screenshot.png
   - vendor

--- a/_config.yml
+++ b/_config.yml
@@ -125,4 +125,6 @@ plugins:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - Rakefile
+  - README.md
   - vendor


### PR DESCRIPTION
There's no need to include these files in `_site`:

1. Rakefile
2. README
3. screenshot.png