### PR TITLE
Add lang attribute to html tag

### DIFF
--- a/_layouts/center.html
+++ b/_layouts/center.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 {% include head.html %}
 <body class="site{% if site.animated %} animated fade-in-down{% endif %}">
     {% if site.google_tag_manager %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 {% include head.html %}
 <body class="site{% if site.animated %} animated fade-in-down{% endif %}">
   {% if site.google_tag_manager %}


### PR DESCRIPTION
This is an accessibility issue and an internationalization issue.  

With this, people can set the language with a`lang` value in either:

1. In their `_config.yml`
2. In the preamble to a page or post.

Shamelessly stolen from the Jekyll minima theme.