### PR TITLE
Sync center layout with default

### DIFF
--- a/_layouts/center.html
+++ b/_layouts/center.html
@@ -2,10 +2,21 @@
 <html lang="{{ page.lang | default: site.lang | default: 'en' }}">
 {% include head.html %}
 <body class="site{% if site.animated %} animated fade-in-down{% endif %}">
-    {% if site.google_tag_manager %}
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager }}"
+  {% if site.google_tag_manager %}
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    {% endif %}
+  {% endif %}
+	{% if site.facebook_comments %}
+		<div id="fb-root"></div>
+		<script>(function(d, s, id) {
+		  var js, fjs = d.getElementsByTagName(s)[0];
+		  if (d.getElementById(id)) return;
+		  js = d.createElement(s); js.id = id;
+		  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5&appId={{ site.facebook_appid }}";
+		  fjs.parentNode.insertBefore(js, fjs);
+		}(document, 'script', 'facebook-jssdk'));</script>
+	{% endif %}
+
   <div class="site-wrap center">
     {% include header.html %}
 


### PR DESCRIPTION
After this, the only difference is:

```diff
--- _layouts/default.html
+++ _layouts/center.html
@@ -17,7 +17,7 @@
 		}(document, 'script', 'facebook-jssdk'));</script>
 	{% endif %}
 
-  <div class="site-wrap">
+  <div class="site-wrap center">
     {% include header.html %}
 
     <div class="post p2 p-responsive wrap" role="main">
```