### PR TITLE
Fix reload defect in Chrome

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-var CACHE_NAME = "pixyll2-{{site.time | date: '%Y%m%d%H%M%S'}}";
+var CACHE_NAME = "pixyll2";
 
 self.addEventListener("install", function(e) {
   e.waitUntil(


### PR DESCRIPTION
Seems the service worker is getting in the way of working with Pixyll locally.  I wonder if the date in the cache name is too tricky.

Resolves #414?