### PR TITLE
Ruby 2.3 is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
- - 2.3
  - 2.4
  - 2.5
  - 2.6


### PR DESCRIPTION
Remove from Travis build.

http://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/