### PR TITLE
readme: add other analytics format

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you want to give credit to the Pixyll theme with a link to <https://pixyll.co
 ### Web analytics and search engines
 
 You can measure visits to your website either by using [Google Analytics](https://www.google.com/analytics/) tracking embed or the more advanced [Google Tag Manager](https://www.google.com/analytics/tag-manager/) container.
-* For Google Analytics set up the value for `google_analytics`, it should be something like `google_analytics: UA-XXXXXXXX-X`.
+* For Google Analytics set up the value for `google_analytics`, it should be something like `google_analytics: UA-XXXXXXXX-X` or `google_analytics: G-XXXXXXX` depending on whether you are using universal analytics or not.
 * For Google Tag Manager set up the value for `google_tag_manager`, it should be something like: `google_tag_manager: GTM-XXXXX`.
 * _Do not_ set both of above methods because this will cause conflicts and skew your reporting data.
 * Remember that you need to properly configure the GTM container in its admin panel if you want it to work. More info is available in [GTM's docs](https://www.google.com/analytics/tag-manager/resources/).


### PR DESCRIPTION
update analytics report after EU change, you can see the format here https://support.google.com/sites/answer/97459?hl=en

I was setting up the pixyll google analytics, but i found no code in that format `UA-XXXXXX-X` when i was setting it up.
It turns out that in Europe universal analytics are begin dropped by july, so it has a new format, this pull request is usefull to add the possibility of this new format also in the original readme.
