### PR TITLE
fix: switch to use maintained ruby/setup-ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.x
     - name: Bundle install


### PR DESCRIPTION
Gihub actions/runs log:

Run actions/setup-ruby@v1
------------------------
NOTE: This action is deprecated and is no longer maintained. Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained. ------------------------
Error: Version 2.6.x not found

This patch fixed the problem by switching to use maintained ruby/setup-ruby