### PR TITLE
fix: correct nav header alignment and table border gaps (supersedes #449)

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -14,9 +14,43 @@
   font-size: $h2;
 }
 
+// //   original -- does not work
+// //   if you leave as is, in the
+// //   _media-queries.scss partial add
+// //   padding-top: 0;
+// //   to the .site-nav rule inside the media query
+// //   for an alternate fix
+
+// .site-nav {                     // not working
+//   padding-top: $nav-padding;    // not working
+// }                               // not working
+
+// //   we could just remove the .site-nav rule here
+// //   but in past incarnations, Jan 2019 on the wayback machine
+// //   by inspection this worked, we had just ` margin-top: $space-2; `
+// //   though  margin-top: 0;  seems to be working, go figure.
+// //   or as I say, elminate the whole rule at this location in the file
+// //
+// //   this rule is good
 .site-nav {
-  padding-top: $nav-padding;
+  margin-top: $space-2;
 }
+
+// //   If we do that, we want to remove or
+// //   rename the $nav-padding; variable.
+// //   So there's also a separate commit to remove it.
+
+// //   this would work also, use $nav-padding instead of #space-2
+// //   still setting margin-top instead of padding-top
+// .site-nav {
+//   margin-top: $nav-padding;
+// }
+
+// //  an additional tweak, in _media-queries.scss
+// //  you can lift the left nav text upwards by
+// //  changing the ` .site-header .site-nav ` rule
+// //                   margin-top: .25rem;
+// // to something like .2, .15, ...,  .05rem;
 
 .site-header nav a {
   color: $nav-color;

--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -4,6 +4,7 @@
 */
 
 table {
+  border-collapse: collapse;
   width: 100%;
   max-width: 100%;
   margin-bottom: 1.5rem;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -121,7 +121,6 @@ $header-font-weight: 300;
 // Nav
 $nav-color: $mid-gray;
 $nav-link-color: #444;
-$nav-padding: $space-2;
 $nav-link-padding-x: $space-2;
 $nav-link-border-bottom: 2px solid #444;
 $nav-active-border-bottom: 1px solid $light-gray;


### PR DESCRIPTION
### Pull Request Description

#### Align header/nav text & fix table borders

- Aligns the baselines of the site title and navigation text at the top of each page.
- Fixes doubled and broken horizontal lines in tables.

This pull request supersedes #449 with different commit text and updated options and explanations in comments.

### Changes made:

- Fixed misalignment of site title and navigation links by updating `.site-nav` rule in `_header.scss`.
- Removed unused `$padding-top` variable that becomes obsolete if suggested title/nav CSS fix is chosen.
- Placed detailed comments in `_header.scss` CSS for alternative fixes and an additional tweak.
- Fixed double and broken horizontal lines in tables by setting `border-collapse: collapse` on the main table ruleset.

### Visual Comparison

- **Before (Original site):**  
  [Pixyll in Action – Original](https://www.pixyll.com/jekyll/pixyll/2014/06/10/see-pixyll-in-action/) at pixyll.com
- **After (With my fixes):**  
  [Pixyll in Action – Fixed](https://traven-b.github.io/pixyll/jekyll/pixyll/2014/06/10/see-pixyll-in-action/) at traven-b.github.io
- **Reference Screenshot from README (expected):**  
  ![Reference](https://github.com/johno/pixyll/blob/master/screenshot.png)

On the "Pixyll in Action" page, the navigation/header fix now aligns with the README layout. The example tables further down demonstrate the doubled lines and gap fixes.

### Notes:

See the comment in `_header.scss` for an additional tweak option to pull up the navigation text on the right side by the tiniest amount, if it seems necessary.

The table fix is an obvious, no-mystery one-line addition to `_tables.scss`.

The header alignment fix is my best guess. January 2019 pixyll.com at archive.org shows a good version, February does not.

